### PR TITLE
Add encryption for AWS EC2 EBS volumes by default

### DIFF
--- a/aws/instance.tf
+++ b/aws/instance.tf
@@ -49,6 +49,11 @@ data "template_cloudinit_config" "tor-userdata-only" {
   }
 }
 
+# TODO make this dynamic in case users want to supply their own KMS key
+data "aws_kms_key" "ebs-kms-key" {
+  key_id = "alias/aws/ebs"
+}
+
 resource "aws_key_pair" "torraform-key-pair" {
   count = var.PUBLIC_ssh_key == "ssh-rsa null" ? 0 : 1
   public_key = var.PUBLIC_ssh_key
@@ -71,6 +76,11 @@ resource "aws_instance" "tor-instance" {
 
   tags = {
     Name = "tor-service-server"
+  }
+
+  root_block_device {
+    encrypted = true
+    kms_key_id = data.aws_kms_key.ebs-kms-key.id
   }
 
 

--- a/aws/instance.tf
+++ b/aws/instance.tf
@@ -49,9 +49,8 @@ data "template_cloudinit_config" "tor-userdata-only" {
   }
 }
 
-# TODO make this dynamic in case users want to supply their own KMS key
 data "aws_kms_key" "ebs-kms-key" {
-  key_id = "alias/aws/ebs"
+  key_id = var.kms_key_identifier
 }
 
 resource "aws_key_pair" "torraform-key-pair" {

--- a/aws/instance.tf
+++ b/aws/instance.tf
@@ -51,6 +51,11 @@ data "template_cloudinit_config" "tor-userdata-only" {
   }
 }
 
+# TODO make this dynamic in case users want to supply their own KMS key
+data "aws_kms_key" "ebs-kms-key" {
+  key_id = "alias/aws/ebs"
+}
+
 resource "aws_key_pair" "torraform-key-pair" {
   count = var.PUBLIC_ssh_key == "ssh-rsa null" ? 0 : 1
   public_key = var.PUBLIC_ssh_key
@@ -73,6 +78,11 @@ resource "aws_instance" "tor-instance" {
 
   tags = {
     Name = "tor-service-server"
+  }
+
+  root_block_device {
+    encrypted = true
+    kms_key_id = data.aws_kms_key.ebs-kms-key.id
   }
 
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -52,6 +52,18 @@ variable "subnet_id" {
 }
 
 
+#####################
+# EC2 INSTANCE VARS #
+#####################
+
+# Looking for more info on how this can be set? https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_alias
+variable "kms_key_identifier" {
+  description = "The valid identifier (ARN, alias, or ID) of the KMS key that should be used to encrypt the EBS volume associated with the Tor server. Defaults to alias/aws/kms"
+  type = string
+  default = "alias/aws/ebs"
+}
+
+
 ######################
 # BOOTSTRAPPING VARS #
 ######################


### PR DESCRIPTION
Defaults to the AWS-managed `aws/ebs` KMS key, but user can specify their own KMS key via the variables.tf overrides